### PR TITLE
Simple bug fix

### DIFF
--- a/app/scripts/test-skydome.js
+++ b/app/scripts/test-skydome.js
@@ -149,6 +149,8 @@ var material2 = new THREE.MeshBasicMaterial({
 
 
 // camera.position.y += 0.008;
+// TODO: should really change code to not use a global
+mult = 0;
 var animateTurn = function(time){
 	if (turns[0] == 1)
 		mult = -1;


### PR DESCRIPTION
This PR fixes a bug where player would try to only move forward without ever looking to the sides.

In the current game, if I try to to play the game and hit only forward, the game stops working (an exception is thrown saying `mult` is not defined). It seems `mult` is only defined when the left/right arrow keys are hit. This code just sets `mult` to an initial value.
